### PR TITLE
Add version-label option to deploy command

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -4,12 +4,21 @@
 env_file=".env"
 manifest_file=subgraph.yaml
 manifest_tmp_file="$PWD/.subgraph.tmp.yaml"
+package_json_file="package.json"
 
 # Export environment variables from a file
 export_env() {
   if [ -f "$env_file" ]; then
     set -a
     source $env_file
+  fi
+}
+
+# Export subgraph version from package.json
+get_version() {
+  if [ -f "$package_json_file" ]; then
+    set -a
+    SUBGRAPH_VERSION=v$(jq .version package.json | tr -d '"')
   fi
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,11 +6,14 @@ source "./scripts/common.sh"
 # Export environment variables
 export_env $1
 
+# Export subgraph version from package.json
+get_version
+
 # Prepare manifest
 build_manifest
 
 # Deploy graph
-exec_graph deploy "$SUBGRAPH_NAME --ipfs $IPFS_NODE_ENDPOINT --node $GRAPH_ADMIN_NODE_ENDPOINT"
+exec_graph deploy "$SUBGRAPH_NAME --ipfs $IPFS_NODE_ENDPOINT --node $GRAPH_ADMIN_NODE_ENDPOINT --version-label $SUBGRAPH_VERSION"
 
 # Cleanup
 clear_manifest


### PR DESCRIPTION
The new version of `graph-cli` asks for a version-label when executing the `deploy` command.
Closes https://github.com/CirclesUBI/circles-subgraph/issues/55