### PR TITLE
Migrate ubuntu-16.04 workflows to ubuntu-18.04

### DIFF
--- a/.github/workflows/tagbuild.yml
+++ b/.github/workflows/tagbuild.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-and-push:
     name: build-and-push
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
GitHub will phase out Ubuntu 16.04 runners (`ubuntu-16.04`).
We need to migrate ubuntu-16.04 workflows to ubuntu-18.04.
Reference: https://github.com/actions/virtual-environments/issues/3287